### PR TITLE
Retain original filename

### DIFF
--- a/libraries/ApiImport/ResponseAdapter/Omeka/ItemAdapter.php
+++ b/libraries/ApiImport/ResponseAdapter/Omeka/ItemAdapter.php
@@ -222,6 +222,7 @@ class ApiImport_ResponseAdapter_Omeka_ItemAdapter extends ApiImport_ResponseAdap
         foreach($responseData as $fileData) {
             if(! in_array($fileData['id'], $ids)) {
                 $files[] = array('source'   => $fileData['file_urls']['original'],
+                                 'name' => $fileData['original_filename'],
                                  'metadata' => $this->elementTexts($fileData),
                                  //add the external id so we can produce the map
                                  'externalId' => $fileData['id']


### PR DESCRIPTION
There's code in Omeka that would allow the importer to retain original filename metadata. I think this would make sense to add. Let me know your thoughts.